### PR TITLE
Refactoring, linting, and alternative release action

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,6 +8,7 @@ target = "x86_64-pc-windows-msvc"
 [target.'cfg(all())']
 rustflags = [
   "-Wclippy::all",
+  "-Wclippy::pedantic",
   "-Wclippy::match_same_arms",
   "-Wclippy::semicolon_if_nothing_returned",
   "-Wclippy::single_match_else",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: cybercmd
+          cache-on-failure: true
       - run: echo "::add-matcher::.github/clippy-matcher.json"
       - run: cargo clippy -- -Dwarnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Create Release Artifacts
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+env:
+  CARGO_INCREMENTAL: 0 # Incremental not supported by our caching
+  CARGO_TERM_COLOR: always # GH action logs support terminal colors
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse # New format as of 2023-03-09
+
+jobs:
+  build-release:
+    name: Build and create release
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cybercmd
+          cache-on-failure: true
+      - run: cargo xtask dist
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create ${{  github.ref_name }} --generate-notes $(Resolve-Path -Relative -Path ./target/dist/*.zip)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,18 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aes"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
- "opaque-debug",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "autocfg"
@@ -52,30 +40,15 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
-
-[[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "bumpalo"
@@ -90,40 +63,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
-name = "bytes"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
-
-[[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -138,58 +81,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
-]
-
-[[package]]
-name = "cipher"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "clap"
-version = "4.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce38afc168d8665cfc75c7b1dd9672e50716a137f433f070991619744a67342a"
-dependencies = [
- "bitflags",
- "clap_derive",
- "clap_lex",
- "is-terminal",
- "once_cell",
- "strsim",
- "termcolor",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -208,24 +102,13 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "flexi_logger",
+ "native-tls",
  "normpath",
- "reqwest",
  "thiserror",
+ "ureq",
  "zip",
  "zip-extensions",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -242,15 +125,6 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "crc32fast"
@@ -271,20 +145,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "cxx"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a140f260e6f3f79013b8bfc65e7ce630c9ab4388c6a89c71e07226f49487b72"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -294,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6383f459341ea689374bf0a42979739dc421874f112ff26f829b8040b8e613"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -304,24 +168,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90201c1a650e95ccff1c8c0bb5a343213bdd317c6e600a93075bca2eff54ec97"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -329,32 +193,16 @@ name = "cybercmd"
 version = "0.0.7"
 dependencies = [
  "anyhow",
- "chrono",
  "common",
- "derive_more",
  "detour",
  "log",
  "microtemplate",
  "once_cell",
  "serde",
- "thiserror",
  "toml",
  "uniquote",
  "widestring",
  "winapi",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
 ]
 
 [[package]]
@@ -373,34 +221,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
-dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
-]
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -449,12 +277,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,58 +301,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
-
-[[package]]
-name = "futures-io"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
-
-[[package]]
-name = "futures-task"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
-
-[[package]]
-name = "futures-util"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
-dependencies = [
- "futures-core",
- "futures-io",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -543,44 +317,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "h2"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -589,97 +329,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "http"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
-dependencies = [
- "bytes",
- "http",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
-
-[[package]]
-name = "httpdate"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "hyper"
-version = "0.14.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0c17cc76786e99f8d2f055c11159e7f0091c42474dcc3189fbab96072e873e6d"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -704,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -723,46 +383,25 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e86b86ae312accbf05ade23ce76b625e0e47a255712b7414037385a1c05380"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys 0.45.0",
 ]
-
-[[package]]
-name = "ipnet"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "itoa"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
-
-[[package]]
-name = "jobserver"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -807,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "log"
@@ -851,14 +490,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fed5a2f7f2444b809e07bf5db99c937af3664b8f7a8f9ad9170727bb29e3f7"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
-
-[[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
@@ -867,18 +500,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -911,12 +532,12 @@ dependencies = [
 
 [[package]]
 name = "normpath"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972dec05f98e7c787ede35d7a9ea4735eb7788c299287352757b3def6cc1f7b5"
+checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
 dependencies = [
  "uniquote",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -949,32 +570,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
-dependencies = [
- "hermit-abi 0.2.6",
- "libc",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "openssl"
-version = "0.10.46"
+version = "0.10.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2523381e46256e40930512c7fd25562b9eae4812cb52078f155e87217c9d1e"
+checksum = "4d2f106ab837a24e03672c59b1239669a0596406ff657c3c0835b6b7f0f35a33"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -987,13 +592,13 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -1004,22 +609,15 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.81"
+version = "0.9.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176be2629957c157240f68f61f2d0053ad3a4ecfdd9ebf1e6521d18d9635cf67"
+checksum = "3a20eace9dc2d82904039cb76dcf50fb1a0bba071cfd1629720b5d6f1ddba0fa"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "overload"
@@ -1028,45 +626,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest",
- "hmac",
- "password-hash",
- "sha2",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1075,34 +638,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "1d0dd4be24fcdcfeaa12a432d588dc59bbad6cad3510c67e74a2b6b2fc950564"
 dependencies = [
  "unicode-ident",
 ]
@@ -1117,25 +656,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1161,56 +694,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-tls",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
-version = "0.36.9"
+version = "0.37.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+checksum = "d097081ed288dfe45699b72f5b5d648e5f15d64d900c7080273baa20c16a6849"
 dependencies = [
  "bitflags",
  "errno",
@@ -1219,12 +706,6 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.45.0",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "schannel"
@@ -1265,40 +746,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
-
-[[package]]
 name = "serde"
-version = "1.0.156"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.156"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -1311,75 +775,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "slice-pool"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "733fc6e5f1bd3a8136f842c9bdea4e5f17c910c2fcc98c90c3aa7604ef5e2e7a"
-
-[[package]]
-name = "socket2"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "subtle"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -1393,16 +792,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.4.0"
+name = "syn"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1424,50 +834,23 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
-dependencies = [
- "serde",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "tinyvec"
@@ -1483,47 +866,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
-dependencies = [
- "autocfg",
- "bytes",
- "libc",
- "memchr",
- "mio",
- "num_cpus",
- "pin-project-lite",
- "socket2",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
-]
 
 [[package]]
 name = "toml"
@@ -1548,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.7"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
 dependencies = [
  "indexmap",
  "serde",
@@ -1560,38 +902,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-service"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
-
-[[package]]
-name = "tracing"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
-dependencies = [
- "cfg-if",
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,9 +909,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d502c968c6a838ead8e69b2ee18ec708802f99db92a0d156705ec9ef801993b"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
@@ -1631,6 +941,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a900eeb2aef304818fb781cf422a42c2f67f760c25927ccc83edc6b0fdfd0c"
 
 [[package]]
+name = "ureq"
+version = "2.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
+dependencies = [
+ "base64",
+ "log",
+ "native-tls",
+ "once_cell",
+ "url",
+]
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,28 +977,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "want"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
-dependencies = [
- "log",
- "try-lock",
-]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,20 +997,8 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1730,7 +1019,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1740,16 +1029,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
-
-[[package]]
-name = "web-sys"
-version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "widestring"
@@ -1789,18 +1068,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1809,7 +1097,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1818,13 +1115,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -1834,10 +1146,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1846,10 +1170,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1858,10 +1194,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1870,21 +1218,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
-name = "winnow"
-version = "0.3.6"
+name = "windows_x86_64_msvc"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
-dependencies = [
- "memchr",
-]
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
-name = "winreg"
-version = "0.10.1"
+name = "winnow"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
 dependencies = [
- "winapi",
+ "memchr",
 ]
 
 [[package]]
@@ -1907,10 +1252,7 @@ name = "xtask"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "clap",
  "common",
- "normpath",
- "once_cell",
  "uniquote",
  "xshell",
 ]
@@ -1921,54 +1263,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
 dependencies = [
- "aes",
  "byteorder",
- "bzip2",
- "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "hmac",
- "pbkdf2",
- "sha1",
- "time 0.3.20",
- "zstd",
 ]
 
 [[package]]
 name = "zip-extensions"
 version = "0.6.2"
-source = "git+https://github.com/AndASM/zip-extensions-rs.git?tag=v0.6.2#98a26e266afa818c111256544604e353775f6fc4"
+source = "git+https://github.com/AndASM/zip-extensions-rs.git?tag=v0.6.3#431c62a93507f64bb54b986d3f88fe13ac0949c2"
 dependencies = [
  "zip",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.7+zstd.1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,25 +13,23 @@ test = { path = "crates/test", version = "0.0.0" }
 xtask = { path = "crates/xtask", version = "0.0.0" }
 
 anyhow = "1"
-chrono = "0.4.24"
-clap = { version = "4", features = ["cargo"] }
-derive_more = "0.99"
 detour = { git = "https://github.com/veeenu/detour-rs", rev = "ec23632" }
 flexi_logger = "0.25"
 log = "0.4"
 microtemplate = "1"
+native-tls = "0.2"
 normpath = "1"
 once_cell = "1"
-reqwest = "0.11"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 toml = "0.7"
 uniquote = "3.3.0"
+ureq = { version = "2", default-features = false }
 widestring = "1"
 winapi = { version = "0.3" }
 xshell = "0.2"
-zip = "0.6"
-zip-extensions = { git = "https://github.com/AndASM/zip-extensions-rs.git", tag = "v0.6.2" }
+zip = { version = "0.6", default-features = false }
+zip-extensions = { git = "https://github.com/AndASM/zip-extensions-rs.git", tag = "v0.6.3" }
 
 [profile.release]
 lto = true

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -7,11 +7,18 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[features]
+logger = ["dep:flexi_logger"]
+download = ["dep:ureq", "dep:native-tls"]
+zip = ["dep:zip", "dep:zip-extensions"]
+path = ["dep:normpath"]
+
 [dependencies]
-anyhow = { workspace = true }
-flexi_logger = { workspace = true }
-normpath = { workspace = true, features = ["uniquote"] }
-reqwest = { workspace = true, features = ["blocking"] }
-thiserror = { workspace = true }
-zip = { workspace = true }
-zip-extensions = { workspace = true }
+anyhow.workspace = true
+flexi_logger = { workspace = true, optional = true }
+native-tls = { workspace = true, optional = true }
+normpath = { workspace = true, features = ["uniquote"], optional = true }
+thiserror.workspace = true
+ureq = { workspace = true, optional = true, default-features = false, features = ["native-tls"] }
+zip = { workspace = true, optional = true, default-features = false, features = ["deflate"] }
+zip-extensions = { workspace = true, optional = true }

--- a/crates/common/src/extensions/base_path.rs
+++ b/crates/common/src/extensions/base_path.rs
@@ -2,16 +2,16 @@ use std::ffi::OsString;
 
 use normpath::PathExt;
 
-use crate::path::{Error, Path, PathBuf};
+use crate::path::{Error as PathError, Path, PathBuf};
 
 pub trait Extensions: private::Sealed {
     fn ancestors(&self) -> AncestorsExtension<'_>;
     /// # Errors
     /// Returns `PathErrors`
-    fn common_root(&self, sibling: impl AsRef<std::path::Path>) -> Result<PathBuf, Error>;
+    fn common_root(&self, sibling: impl AsRef<std::path::Path>) -> Result<PathBuf, PathError>;
     /// # Errors
     /// Returns `PathErrors`
-    fn relative_to(&self, sibling: impl AsRef<std::path::Path>) -> Result<PathBuf, Error>;
+    fn relative_to(&self, sibling: impl AsRef<std::path::Path>) -> Result<PathBuf, PathError>;
 }
 
 impl Extensions for Path {
@@ -19,7 +19,7 @@ impl Extensions for Path {
         AncestorsExtension { next: Some(self) }
     }
 
-    fn common_root(&self, sibling: impl AsRef<std::path::Path>) -> Result<PathBuf, Error> {
+    fn common_root(&self, sibling: impl AsRef<std::path::Path>) -> Result<PathBuf, PathError> {
         let me = self.normalize()?;
         let me = me.components();
         let sibling = sibling.as_ref().normalize()?;
@@ -34,12 +34,12 @@ impl Extensions for Path {
             common_root.push(match_components.0.as_os_str());
         }
         if common_root.as_os_str().is_empty() {
-            return Err(Error::NoCommonRoot);
+            return Err(PathError::NoCommonRoot);
         }
         Ok(common_root)
     }
 
-    fn relative_to(&self, sibling: impl AsRef<std::path::Path>) -> Result<PathBuf, Error> {
+    fn relative_to(&self, sibling: impl AsRef<std::path::Path>) -> Result<PathBuf, PathError> {
         let me = self.normalize()?;
         let me = me.components();
         let sibling = sibling.as_ref().normalize()?;
@@ -54,7 +54,7 @@ impl Extensions for Path {
             relative_branch.push(match_components.0.as_os_str());
         }
         if relative_branch.as_os_str().is_empty() {
-            return Err(Error::NoCommonRoot);
+            return Err(PathError::NoCommonRoot);
         }
         Ok(relative_branch)
     }

--- a/crates/common/src/extensions/base_path.rs
+++ b/crates/common/src/extensions/base_path.rs
@@ -8,10 +8,10 @@ pub trait Extensions: private::Sealed {
     fn ancestors(&self) -> AncestorsExtension<'_>;
     /// # Errors
     /// Returns `PathErrors`
-    fn common_root<P: AsRef<std::path::Path>>(&self, sibling: P) -> Result<PathBuf, Error>;
+    fn common_root(&self, sibling: impl AsRef<std::path::Path>) -> Result<PathBuf, Error>;
     /// # Errors
     /// Returns `PathErrors`
-    fn relative_to<P: AsRef<std::path::Path>>(&self, sibling: P) -> Result<PathBuf, Error>;
+    fn relative_to(&self, sibling: impl AsRef<std::path::Path>) -> Result<PathBuf, Error>;
 }
 
 impl Extensions for Path {
@@ -19,7 +19,7 @@ impl Extensions for Path {
         AncestorsExtension { next: Some(self) }
     }
 
-    fn common_root<P: AsRef<std::path::Path>>(&self, sibling: P) -> Result<PathBuf, Error> {
+    fn common_root(&self, sibling: impl AsRef<std::path::Path>) -> Result<PathBuf, Error> {
         let me = self.normalize()?;
         let me = me.components();
         let sibling = sibling.as_ref().normalize()?;
@@ -39,7 +39,7 @@ impl Extensions for Path {
         Ok(common_root)
     }
 
-    fn relative_to<P: AsRef<std::path::Path>>(&self, sibling: P) -> Result<PathBuf, Error> {
+    fn relative_to(&self, sibling: impl AsRef<std::path::Path>) -> Result<PathBuf, Error> {
         let me = self.normalize()?;
         let me = me.components();
         let sibling = sibling.as_ref().normalize()?;

--- a/crates/common/src/extensions/mod.rs
+++ b/crates/common/src/extensions/mod.rs
@@ -1,4 +1,7 @@
-pub use base_path::BasePathExt;
+#[cfg(feature = "path")]
+pub use base_path::Extensions;
+#[cfg(feature = "path")]
 pub use normpath::PathExt;
 
+#[cfg(feature = "path")]
 mod base_path;

--- a/crates/common/src/file.rs
+++ b/crates/common/src/file.rs
@@ -8,7 +8,7 @@ use zip_extensions::ZipWriterExtensions;
 #[cfg(feature = "download")]
 /// # Errors
 /// Returns `anyhow::Error` wrapping a `native_tls::Error`, `ureq::Error`, or `std::io::Error`
-pub fn download<S: AsRef<str>, P: AsRef<Path>>(source: S, dest: P) -> anyhow::Result<()> {
+pub fn download(source: impl AsRef<str>, dest: impl AsRef<Path>) -> anyhow::Result<()> {
     // Use native-tls (Windows' tls)
     let agent = ureq::AgentBuilder::new()
         .tls_connector(Arc::new(native_tls::TlsConnector::new()?))

--- a/crates/common/src/file.rs
+++ b/crates/common/src/file.rs
@@ -24,10 +24,7 @@ pub fn download(source: impl AsRef<str>, dest: impl AsRef<Path>) -> anyhow::Resu
 #[cfg(feature = "zip")]
 /// # Errors
 /// Returns `anyhow::Error` wrapping a `zip::ZipError`, or `std::io::Error`
-pub fn zip_files<P1: AsRef<Path>, P2: AsRef<Path>>(
-    source: P1,
-    destination: P2,
-) -> anyhow::Result<()> {
+pub fn zip_files(source: impl AsRef<Path>, destination: impl AsRef<Path>) -> anyhow::Result<()> {
     let mut dest_file = File::create(destination.as_ref())?;
     let mut zip = zip::ZipWriter::new(&mut dest_file);
     let options = zip::write::FileOptions::default()

--- a/crates/common/src/file.rs
+++ b/crates/common/src/file.rs
@@ -1,16 +1,29 @@
-use std::{fs::File, path::Path};
+use std::{fs::File, io::copy, path::Path, sync::Arc};
 
-use reqwest::blocking as reqwest;
+#[cfg(feature = "zip")]
 use zip::CompressionMethod;
+#[cfg(feature = "zip")]
 use zip_extensions::ZipWriterExtensions;
 
-pub fn download_file<S: AsRef<str>, P: AsRef<Path>>(source: S, dest: P) -> anyhow::Result<()> {
-    let mut response = reqwest::get(source.as_ref())?;
+#[cfg(feature = "download")]
+/// # Errors
+/// Returns `anyhow::Error` wrapping a `native_tls::Error`, `ureq::Error`, or `std::io::Error`
+pub fn download<S: AsRef<str>, P: AsRef<Path>>(source: S, dest: P) -> anyhow::Result<()> {
+    // Use native-tls (Windows' tls)
+    let agent = ureq::AgentBuilder::new()
+        .tls_connector(Arc::new(native_tls::TlsConnector::new()?))
+        .build();
+
+    let response = agent.get(source.as_ref()).call()?;
     let mut file = File::create(dest.as_ref())?;
-    let _ = &response.copy_to(&mut file)?;
+    let mut reader = response.into_reader();
+    copy(&mut reader, &mut file)?;
     Ok(())
 }
 
+#[cfg(feature = "zip")]
+/// # Errors
+/// Returns `anyhow::Error` wrapping a `zip::ZipError`, or `std::io::Error`
 pub fn zip_files<P1: AsRef<Path>, P2: AsRef<Path>>(
     source: P1,
     destination: P2,

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,6 +1,10 @@
-pub use logger::setup_logger;
+#[cfg(feature = "logger")]
+pub use logger::setup;
 
 pub mod extensions;
+#[cfg(any(feature = "download", feature = "zip"))]
 pub mod file;
+#[cfg(feature = "logger")]
 mod logger;
+#[cfg(feature = "path")]
 pub mod path;

--- a/crates/common/src/logger.rs
+++ b/crates/common/src/logger.rs
@@ -5,7 +5,9 @@ use flexi_logger::{
 
 // Blatantly stol... borrowed from https://github.com/jac3km4/redscript
 // Both projects are MIT licensed with the same original author, jekky
-pub fn setup_logger<P: AsRef<std::path::Path>>(logs_dir: P) -> Result<(), FlexiLoggerError> {
+/// # Errors
+/// Returns `FlexiLoggerError`
+pub fn setup<P: AsRef<std::path::Path>>(logs_dir: P) -> Result<(), FlexiLoggerError> {
     let file = FileSpec::default()
         .directory(logs_dir.as_ref())
         .basename("cybercmd");

--- a/crates/common/src/logger.rs
+++ b/crates/common/src/logger.rs
@@ -7,7 +7,7 @@ use flexi_logger::{
 // Both projects are MIT licensed with the same original author, jekky
 /// # Errors
 /// Returns `FlexiLoggerError`
-pub fn setup<P: AsRef<std::path::Path>>(logs_dir: P) -> Result<(), FlexiLoggerError> {
+pub fn setup(logs_dir: impl AsRef<std::path::Path>) -> Result<(), FlexiLoggerError> {
     let file = FileSpec::default()
         .directory(logs_dir.as_ref())
         .basename("cybercmd");

--- a/crates/common/src/path.rs
+++ b/crates/common/src/path.rs
@@ -3,9 +3,8 @@ use std::{fs::create_dir_all, io};
 use normpath::BasePathBuf;
 #[allow(clippy::module_name_repetitions)]
 pub use normpath::{error::*, BasePath as Path, BasePathBuf as PathBuf};
-use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Cannot get root directory")]
     IO {

--- a/crates/common/src/path.rs
+++ b/crates/common/src/path.rs
@@ -1,11 +1,12 @@
 use std::{fs::create_dir_all, io};
 
 use normpath::BasePathBuf;
+#[allow(clippy::module_name_repetitions)]
 pub use normpath::{error::*, BasePath as Path, BasePathBuf as PathBuf};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum PathsError {
+pub enum Error {
     #[error("Cannot get root directory")]
     IO {
         #[from]
@@ -20,6 +21,7 @@ pub enum PathsError {
 }
 
 #[doc(hidden)]
+#[allow(clippy::module_name_repetitions)]
 pub fn _internal_make_path(path: &mut BasePathBuf) {
     *path = {
         if let Ok(normalized) = path.normalize() {
@@ -39,6 +41,7 @@ pub fn _internal_make_path(path: &mut BasePathBuf) {
 }
 
 #[macro_export]
+#[allow(clippy::module_name_repetitions)]
 macro_rules! make_path {
     ($first:expr, $($segments:expr),+) => {{
         let mut path = $crate::path::PathBuf::new($first).expect("Invalid base path!");

--- a/crates/cybercmd/Cargo.toml
+++ b/crates/cybercmd/Cargo.toml
@@ -13,17 +13,14 @@ rust-version.workspace = true
 crate-type = ["rlib", "cdylib"]
 
 [dependencies]
-anyhow = { workspace = true }
-chrono = { workspace = true }
-common = { workspace = true }
-derive_more = { workspace = true }
-detour = { workspace = true }
-log = { workspace = true }
-microtemplate = { workspace = true }
-once_cell = { workspace = true }
-serde = { workspace = true }
-thiserror = { workspace = true }
-toml = { workspace = true }
-uniquote = { workspace = true }
-widestring = { workspace = true }
+anyhow.workspace = true
+common = { workspace = true, features = ["logger", "path"] }
+detour.workspace = true
+log.workspace = true
+microtemplate.workspace = true
+once_cell.workspace = true
+serde.workspace = true
+toml.workspace = true
+uniquote.workspace = true
+widestring.workspace = true
 winapi = { workspace = true, features = ["minwindef", "winnt", "libloaderapi"] }

--- a/crates/cybercmd/src/config/app_context.rs
+++ b/crates/cybercmd/src/config/app_context.rs
@@ -1,7 +1,7 @@
 use common::{
     extensions::{Extensions, PathExt},
     make_path,
-    path::{Error, PathBuf},
+    path::{Error as PathError, PathBuf},
     setup,
 };
 use log::info;
@@ -41,12 +41,12 @@ impl Paths {
         }
     }
 
-    fn get_game_path() -> Result<PathBuf, Error> {
+    fn get_game_path() -> Result<PathBuf, PathError> {
         let game_path = std::env::current_exe()?
             .normalize()?
             .ancestors()
             .nth(3)
-            .ok_or(Error::NoParent)?
+            .ok_or(PathError::NoParent)?
             .normalize_virtually()?;
 
         Ok(game_path)

--- a/crates/cybercmd/src/config/app_context.rs
+++ b/crates/cybercmd/src/config/app_context.rs
@@ -1,8 +1,8 @@
 use common::{
-    extensions::*,
+    extensions::{Extensions, PathExt},
     make_path,
-    path::{PathBuf, PathsError},
-    setup_logger,
+    path::{Error, PathBuf},
+    setup,
 };
 use log::info;
 
@@ -41,12 +41,12 @@ impl Paths {
         }
     }
 
-    fn get_game_path() -> Result<PathBuf, PathsError> {
+    fn get_game_path() -> Result<PathBuf, Error> {
         let game_path = std::env::current_exe()?
             .normalize()?
             .ancestors()
             .nth(3)
-            .ok_or(PathsError::NoParent)?
+            .ok_or(Error::NoParent)?
             .normalize_virtually()?;
 
         Ok(game_path)
@@ -54,9 +54,11 @@ impl Paths {
 }
 
 impl AppContext {
+    /// # Errors
+    /// Returns `anyhow::Error` aggregating many error types.
     pub fn new() -> anyhow::Result<AppContext> {
         let paths = Paths::new();
-        setup_logger(&paths.logs)?;
+        setup(&paths.logs)?;
         info!("Loading Cybercmd");
 
         let app_context = AppContext {

--- a/crates/cybercmd/src/config/argument_context.rs
+++ b/crates/cybercmd/src/config/argument_context.rs
@@ -10,6 +10,7 @@ use crate::AppContext;
 pub struct ArgumentContext(HashMap<String, String>);
 
 impl ArgumentContext {
+    #[must_use]
     pub fn new(paths: &Paths) -> Self {
         Self(
             [(
@@ -20,6 +21,7 @@ impl ArgumentContext {
         )
     }
 
+    #[must_use]
     pub fn from(context: &AppContext, hash_map: &HashMap<String, String>) -> Self {
         let mut new_context = Self::new(&context.paths);
         new_context.0.extend(hash_map.iter().map(|(key, val)| {

--- a/crates/cybercmd/src/config/argument_context.rs
+++ b/crates/cybercmd/src/config/argument_context.rs
@@ -37,6 +37,6 @@ impl ArgumentContext {
 
 impl microtemplate::Context for ArgumentContext {
     fn get_field(&self, field_name: &str) -> &str {
-        self.0.get(field_name).map(AsRef::as_ref).unwrap_or("")
+        self.0.get(field_name).map_or("", AsRef::as_ref)
     }
 }

--- a/crates/cybercmd/src/config/game_config.rs
+++ b/crates/cybercmd/src/config/game_config.rs
@@ -1,49 +1,6 @@
-use std::{collections::HashMap, ffi::OsStr, fs};
+use std::collections::HashMap;
 
-use common::extensions::*;
-use derive_more::{Index, IntoIterator};
 use serde::Deserialize;
-use uniquote::Quote;
-
-use crate::config::app_context::Paths;
-
-#[derive(Index, IntoIterator)]
-pub struct GameConfigList(#[into_iterator(ref)] Vec<GameConfig>);
-
-impl GameConfigList {
-    pub fn new(paths: &Paths) -> anyhow::Result<Self> {
-        let mut game_configs: Vec<GameConfig> = Vec::new();
-
-        let path = &paths.configs;
-
-        log::debug!("Getting configs.");
-
-        for entry in fs::read_dir(path)? {
-            let entry = entry?;
-
-            if entry.path().extension() == Some(OsStr::new("toml")) {
-                log::debug!("Loading: {}", entry.path().normalize_virtually()?.quote());
-                let contents = fs::read_to_string(entry.path())?;
-                match toml::from_str::<GameConfig>(&contents) {
-                    Ok(mut mod_config) => {
-                        mod_config.file_name = entry.path().display().to_string();
-                        game_configs.push(mod_config);
-                    }
-                    Err(error) => log::error!(
-                        "In {} ({}): {}",
-                        &entry.path().normalize_virtually()?.quote(),
-                        match error.span() {
-                            Some(val) => format!("{:?}", val),
-                            None => String::new(),
-                        },
-                        error.message()
-                    ),
-                };
-            }
-        }
-        Ok(Self(game_configs))
-    }
-}
 
 #[derive(Debug, Deserialize)]
 pub struct GameConfig {

--- a/crates/cybercmd/src/config/game_config_list.rs
+++ b/crates/cybercmd/src/config/game_config_list.rs
@@ -1,0 +1,75 @@
+use std::{ffi::OsStr, fs};
+
+use common::extensions::PathExt;
+use uniquote::Quote;
+
+use super::{app_context::Paths, GameConfig};
+
+pub struct GameConfigList(Vec<GameConfig>);
+
+impl<T> core::ops::Index<T> for GameConfigList
+where
+    Vec<GameConfig>: core::ops::Index<T>,
+{
+    type Output = <Vec<GameConfig> as core::ops::Index<T>>::Output;
+
+    #[inline]
+    fn index(&self, idx: T) -> &Self::Output {
+        <Vec<GameConfig> as core::ops::Index<T>>::index(&self.0, idx)
+    }
+}
+
+impl IntoIterator for GameConfigList {
+    type IntoIter = <Vec<GameConfig> as IntoIterator>::IntoIter;
+    type Item = <Vec<GameConfig> as IntoIterator>::Item;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        <Vec<GameConfig> as IntoIterator>::into_iter(self.0)
+    }
+}
+
+impl<'a> IntoIterator for &'a GameConfigList {
+    type IntoIter = <&'a Vec<GameConfig> as IntoIterator>::IntoIter;
+    type Item = <&'a Vec<GameConfig> as IntoIterator>::Item;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        <&'a Vec<GameConfig> as IntoIterator>::into_iter(&self.0)
+    }
+}
+
+impl GameConfigList {
+    pub fn new(paths: &Paths) -> anyhow::Result<Self> {
+        let mut game_configs: Vec<GameConfig> = Vec::new();
+
+        let path = &paths.configs;
+
+        log::debug!("Getting configs.");
+
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+
+            if entry.path().extension() == Some(OsStr::new("toml")) {
+                log::debug!("Loading: {}", entry.path().normalize_virtually()?.quote());
+                let contents = fs::read_to_string(entry.path())?;
+                match toml::from_str::<GameConfig>(&contents) {
+                    Ok(mut mod_config) => {
+                        mod_config.file_name = entry.path().display().to_string();
+                        game_configs.push(mod_config);
+                    }
+                    Err(error) => log::error!(
+                        "In {} ({}): {}",
+                        &entry.path().normalize_virtually()?.quote(),
+                        match error.span() {
+                            Some(val) => format!("{val:?}"),
+                            None => String::new(),
+                        },
+                        error.message()
+                    ),
+                };
+            }
+        }
+        Ok(Self(game_configs))
+    }
+}

--- a/crates/cybercmd/src/config/game_config_list.rs
+++ b/crates/cybercmd/src/config/game_config_list.rs
@@ -25,7 +25,7 @@ impl IntoIterator for GameConfigList {
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-       self.0.into_iter()
+        self.0.into_iter()
     }
 }
 

--- a/crates/cybercmd/src/config/game_config_list.rs
+++ b/crates/cybercmd/src/config/game_config_list.rs
@@ -15,7 +15,7 @@ where
 
     #[inline]
     fn index(&self, idx: T) -> &Self::Output {
-        <Vec<GameConfig> as core::ops::Index<T>>::index(&self.0, idx)
+        self.0.index(idx)
     }
 }
 
@@ -25,7 +25,7 @@ impl IntoIterator for GameConfigList {
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        <Vec<GameConfig> as IntoIterator>::into_iter(self.0)
+       self.0.into_iter()
     }
 }
 
@@ -35,7 +35,7 @@ impl<'a> IntoIterator for &'a GameConfigList {
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        <&'a Vec<GameConfig> as IntoIterator>::into_iter(&self.0)
+        self.0.iter()
     }
 }
 

--- a/crates/cybercmd/src/config/mod.rs
+++ b/crates/cybercmd/src/config/mod.rs
@@ -1,10 +1,14 @@
+pub(self) use game_config_list::GameConfigList;
+
+pub(self) use self::app_context::Paths;
+#[allow(clippy::module_name_repetitions)]
 pub use self::{
     app_context::AppContext,
     argument_context::ArgumentContext,
     game_config::{GameConfig, Task},
 };
-pub(self) use self::{app_context::Paths, game_config::GameConfigList};
 
 mod app_context;
 mod argument_context;
 mod game_config;
+mod game_config_list;

--- a/crates/cybercmd/src/lib.rs
+++ b/crates/cybercmd/src/lib.rs
@@ -69,7 +69,7 @@ fn get_final_cmd(context: &AppContext, initial_cmd_ustr: &U16CStr) -> Result<U16
 
     for mod_config in &context.game_configs {
         write_mod_cmd(context, mod_config, &mut cmd)?;
-        run_mod_tasks(context, mod_config)?;
+        run_mod_tasks(context, mod_config);
     }
     Ok(U16CString::from_str(cmd)?)
 }
@@ -82,7 +82,7 @@ fn write_mod_cmd<W: Write>(context: &AppContext, config: &GameConfig, mut writer
     Ok(())
 }
 
-fn run_mod_tasks(context: &AppContext, config: &GameConfig) -> Result<()> {
+fn run_mod_tasks(context: &AppContext, config: &GameConfig) {
     const NO_WINDOW_FLAGS: u32 = 0x0800_0000;
 
     for task in &config.tasks {
@@ -137,7 +137,6 @@ fn run_mod_tasks(context: &AppContext, config: &GameConfig) -> Result<()> {
             }
         }
     }
-    Ok(())
 }
 
 fn get_command_path(context: &AppContext, task: &Task) -> Result<PathBuf> {
@@ -180,7 +179,7 @@ pub unsafe extern "system" fn DllMain(
     _reserved: LPVOID,
 ) -> BOOL {
     if call_reason == DLL_PROCESS_ATTACH && is_valid_exe() {
-        return main().is_ok() as BOOL;
+        return i32::from(main().is_ok());
     }
     TRUE
 }

--- a/crates/cybercmd/src/lib.rs
+++ b/crates/cybercmd/src/lib.rs
@@ -74,7 +74,7 @@ fn get_final_cmd(context: &AppContext, initial_cmd_ustr: &U16CStr) -> Result<U16
     Ok(U16CString::from_str(cmd)?)
 }
 
-fn write_mod_cmd<W: Write>(context: &AppContext, config: &GameConfig, mut writer: W) -> Result<()> {
+fn write_mod_cmd(context: &AppContext, config: &GameConfig, mut writer: impl Write) -> Result<()> {
     for (key, val) in &config.args {
         let rendered = render(val, context.argument_context.clone());
         write!(writer, " -{key} {rendered:?}")?;

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -8,5 +8,5 @@ license.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-widestring = { workspace = true }
+widestring.workspace = true
 winapi = { workspace = true, features = ["winver", "processenv", "winbase"] }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -8,10 +8,7 @@ license.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
-clap = { workspace = true, features = ["derive", "cargo"] }
-common = { workspace = true }
-normpath = { workspace = true }
-once_cell = { workspace = true }
-uniquote = { workspace = true }
-xshell = { workspace = true }
+anyhow.workspace = true
+common = { workspace = true, features = ["path", "zip", "download"] }
+uniquote.workspace = true
+xshell.workspace = true

--- a/crates/xtask/src/config.rs
+++ b/crates/xtask/src/config.rs
@@ -73,6 +73,13 @@ impl Paths {
         Ok(())
     }
 
+    pub fn clean_dist(&self) -> anyhow::Result<()> {
+    println!("Removing: {:?}", &self.dist);
+    remove_dir_all(&self.dist)?;
+    create_dir_all(&self.dist)?;
+    Ok(())
+    }
+
     fn project_root() -> Result<PathBuf, PathsError> {
         let manifest_dir = PathBuf::new(env!("CARGO_MANIFEST_DIR"))?;
         let exe_path = std::env::current_exe()?;

--- a/crates/xtask/src/config.rs
+++ b/crates/xtask/src/config.rs
@@ -3,7 +3,7 @@ use std::fs::{create_dir_all, remove_dir_all};
 use common::{
     extensions::{Extensions, PathExt},
     make_path,
-    path::{Error, PathBuf},
+    path::{Error as PathError, PathBuf},
 };
 
 #[derive(Debug)]
@@ -84,7 +84,7 @@ impl Paths {
         Ok(())
     }
 
-    fn project_root() -> Result<PathBuf, Error> {
+    fn project_root() -> Result<PathBuf, PathError> {
         let manifest_dir = PathBuf::new(env!("CARGO_MANIFEST_DIR"))?;
         let exe_path = std::env::current_exe()?;
         let root = manifest_dir.common_root(exe_path)?;
@@ -94,12 +94,12 @@ impl Paths {
 
     // This will be the /target directory, or something like /target/x86_64-pc-windows-msvc depending
     // on cargo's invocation and options
-    fn target_platform_path() -> Result<PathBuf, Error> {
+    fn target_platform_path() -> Result<PathBuf, PathError> {
         let root = std::env::current_exe()?
             .normalize()?
             .ancestors()
             .nth(2)
-            .ok_or(Error::NoParent)?
+            .ok_or(PathError::NoParent)?
             .normalize_virtually()?;
 
         Ok(root)

--- a/crates/xtask/src/config.rs
+++ b/crates/xtask/src/config.rs
@@ -1,9 +1,9 @@
 use std::fs::{create_dir_all, remove_dir_all};
 
 use common::{
-    extensions::*,
+    extensions::{Extensions, PathExt},
     make_path,
-    path::{PathBuf, PathsError},
+    path::{Error, PathBuf},
 };
 
 #[derive(Debug)]
@@ -69,18 +69,22 @@ impl Paths {
         create_dir_all(&self.staging_bin)?;
         create_dir_all(&self.staging_plugins)?;
         create_dir_all(&self.staging_config)?;
+        Ok(())
+    }
+
+    pub fn create_fomod(&self) -> anyhow::Result<()> {
         create_dir_all(&self.staging_fomod)?;
         Ok(())
     }
 
     pub fn clean_dist(&self) -> anyhow::Result<()> {
-    println!("Removing: {:?}", &self.dist);
-    remove_dir_all(&self.dist)?;
-    create_dir_all(&self.dist)?;
-    Ok(())
+        println!("Removing: {:?}", &self.dist);
+        remove_dir_all(&self.dist)?;
+        create_dir_all(&self.dist)?;
+        Ok(())
     }
 
-    fn project_root() -> Result<PathBuf, PathsError> {
+    fn project_root() -> Result<PathBuf, Error> {
         let manifest_dir = PathBuf::new(env!("CARGO_MANIFEST_DIR"))?;
         let exe_path = std::env::current_exe()?;
         let root = manifest_dir.common_root(exe_path)?;
@@ -90,12 +94,12 @@ impl Paths {
 
     // This will be the /target directory, or something like /target/x86_64-pc-windows-msvc depending
     // on cargo's invocation and options
-    fn target_platform_path() -> Result<PathBuf, PathsError> {
+    fn target_platform_path() -> Result<PathBuf, Error> {
         let root = std::env::current_exe()?
             .normalize()?
             .ancestors()
             .nth(2)
-            .ok_or(PathsError::NoParent)?
+            .ok_or(Error::NoParent)?
             .normalize_virtually()?;
 
         Ok(root)

--- a/crates/xtask/src/dist.rs
+++ b/crates/xtask/src/dist.rs
@@ -25,6 +25,9 @@ pub fn dist(config: &Config<'_>) -> Result<()> {
         ],
     )?;
 
+    println!("Cleanup dist");
+    config.paths.clean_dist()?;
+
     let main_zip = &config.paths.dist.join("cybercmd.zip");
     println!("Creating: {}", main_zip.quote());
     zip_files(&config.paths.staging, main_zip)?;

--- a/crates/xtask/src/dist.rs
+++ b/crates/xtask/src/dist.rs
@@ -5,7 +5,7 @@ use xshell::Shell;
 
 use crate::{
     config::Config,
-    stage::{stage, stage_add_standalone},
+    stage::{stage, stage_add_standalone, stage_fomod, RELEASE_ARGS},
 };
 
 pub fn dist(config: &Config<'_>) -> Result<()> {
@@ -13,17 +13,8 @@ pub fn dist(config: &Config<'_>) -> Result<()> {
 
     println!();
     println!("Start: Building distribution files");
-    stage(
-        config,
-        &sh,
-        &vec![
-            "-Z",
-            "build-std=std,panic_abort",
-            "-Z",
-            "build-std-features=panic_immediate_abort",
-            "--release",
-        ],
-    )?;
+    stage(config, &sh, &RELEASE_ARGS)?;
+    stage_fomod(config, &sh)?;
 
     println!("Cleanup dist");
     config.paths.clean_dist()?;

--- a/crates/xtask/src/install.rs
+++ b/crates/xtask/src/install.rs
@@ -29,11 +29,7 @@ pub fn install(config: &Config<'_>, game_dir: impl AsRef<Path>) -> Result<()> {
     Ok(())
 }
 
-fn recursive_copy<P1: AsRef<Path>, P2: AsRef<Path>>(
-    source: &P1,
-    dest: &P2,
-    sh: &Shell,
-) -> Result<()> {
+fn recursive_copy(source: &impl AsRef<Path>, dest: &impl AsRef<Path>, sh: &Shell) -> Result<()> {
     for entry in fs::read_dir(source)? {
         let entry = entry?;
         if entry.file_type()?.is_dir() {

--- a/crates/xtask/src/install.rs
+++ b/crates/xtask/src/install.rs
@@ -8,7 +8,7 @@ use crate::{
     stage::{stage, RELEASE_ARGS},
 };
 
-pub fn install<P: AsRef<Path>>(config: &Config<'_>, game_dir: P) -> Result<()> {
+pub fn install(config: &Config<'_>, game_dir: impl AsRef<Path>) -> Result<()> {
     let sh = Shell::new()?;
 
     println!();

--- a/crates/xtask/src/install.rs
+++ b/crates/xtask/src/install.rs
@@ -1,24 +1,21 @@
-use std::{fs, path::Path};
+use std::{fs, fs::create_dir_all, path::Path};
 
 use anyhow::Result;
-use xshell::{cmd, Shell};
+use xshell::Shell;
 
-use crate::config::Config;
+use crate::{
+    config::Config,
+    stage::{stage, RELEASE_ARGS},
+};
 
 pub fn install<P: AsRef<Path>>(config: &Config<'_>, game_dir: P) -> Result<()> {
     let sh = Shell::new()?;
-    let cargo = &config.cargo_cmd;
 
-    cmd!(
-        sh,
-        "{cargo} build -Z build-std --release --package cybercmd"
-    )
-    .run()?;
+    println!();
+    println!("Start: Building distribution files");
+    stage(config, &sh, &RELEASE_ARGS)?;
 
-    println!("Adding config files (redscript)");
-    for path in fs::read_dir(&config.paths.config)? {
-        sh.copy_file(path?.path(), game_dir.as_ref().join("r6/config/cybercmd"))?;
-    }
+    recursive_copy(&config.paths.staging, &game_dir, &sh)?;
 
     println!("Copying cybercmd.asi");
     sh.copy_file(
@@ -28,6 +25,25 @@ pub fn install<P: AsRef<Path>>(config: &Config<'_>, game_dir: P) -> Result<()> {
 
     println!();
     println!("Done!");
+
+    Ok(())
+}
+
+fn recursive_copy<P1: AsRef<Path>, P2: AsRef<Path>>(
+    source: &P1,
+    dest: &P2,
+    sh: &Shell,
+) -> Result<()> {
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            let new_dest = dest.as_ref().join(entry.file_name());
+            create_dir_all(&new_dest)?;
+            recursive_copy(&entry.path(), &new_dest, sh)?;
+        } else {
+            sh.copy_file(entry.path(), dest)?;
+        }
+    }
 
     Ok(())
 }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -11,13 +11,6 @@ mod scratch;
 mod stage;
 mod test;
 
-#[macro_export]
-macro_rules! make_cli {
-    ($first:expr, $($segments:expr),+) => {};
-}
-
-make_cli!(dist, install, scratch);
-
 fn main() {
     try_main().expect("Unhandled error");
 }

--- a/crates/xtask/src/scratch.rs
+++ b/crates/xtask/src/scratch.rs
@@ -7,7 +7,7 @@ use crate::config::Config;
 pub fn scratch(config: &Config<'_>) -> Result<()> {
     println!("Scratch!");
     println!();
-    println!("Our config: {:#?}", config);
+    println!("Our config: {config:#?}");
     println!();
     println!("Cargo environment variables:");
     for (key, value) in std::env::vars() {
@@ -22,11 +22,11 @@ pub fn scratch(config: &Config<'_>) -> Result<()> {
 
     let test_path = PathBuf::new(r"C:\Windows\System\user32.dll")?;
     let components = test_path.components();
-    println!("For Path: {:?}", test_path);
-    println!("Components: {:#?}", components);
+    println!("For Path: {test_path:?}");
+    println!("Components: {components:#?}");
     println!("Iterated:");
     for component in components {
-        println!("{:?}", component);
+        println!("{component:?}");
     }
 
     Ok(())

--- a/crates/xtask/src/stage.rs
+++ b/crates/xtask/src/stage.rs
@@ -14,6 +14,8 @@ pub const RELEASE_ARGS: [&str; 5] = [
     "--release",
 ];
 
+pub const TEST_ARGS: [&str; 2] = ["-Z", "build-std=std"];
+
 pub fn stage<I, II>(config: &Config<'_>, sh: &Shell, build_args: &I) -> Result<()>
 where
     I: IntoIterator<Item = II> + Clone,

--- a/crates/xtask/src/test.rs
+++ b/crates/xtask/src/test.rs
@@ -5,7 +5,7 @@ use xshell::{cmd, Shell};
 
 use crate::{
     config::Config,
-    stage::{stage, stage_add_standalone},
+    stage::{stage, stage_add_standalone, RELEASE_ARGS},
 };
 
 pub fn test(config: &Config<'_>) -> Result<()> {
@@ -16,15 +16,7 @@ pub fn test(config: &Config<'_>) -> Result<()> {
     stage(
         config,
         sh,
-        &vec![
-            "--package",
-            "test",
-            "-Z",
-            "build-std=std,panic_abort",
-            "-Z",
-            "build-std-features=panic_immediate_abort",
-            "--release",
-        ],
+        &["--package", "test"].iter().chain(&RELEASE_ARGS),
     )?;
     stage_add_standalone(config)?;
 

--- a/crates/xtask/src/test.rs
+++ b/crates/xtask/src/test.rs
@@ -5,7 +5,7 @@ use xshell::{cmd, Shell};
 
 use crate::{
     config::Config,
-    stage::{stage, stage_add_standalone, RELEASE_ARGS},
+    stage::{stage, stage_add_standalone, TEST_ARGS},
 };
 
 pub fn test(config: &Config<'_>) -> Result<()> {
@@ -13,11 +13,7 @@ pub fn test(config: &Config<'_>) -> Result<()> {
     println!("Start: Running Tester");
     let sh = &Shell::new()?;
 
-    stage(
-        config,
-        sh,
-        &["--package", "test"].iter().chain(&RELEASE_ARGS),
-    )?;
+    stage(config, sh, &["--package", "test"].iter().chain(&TEST_ARGS))?;
     stage_add_standalone(config)?;
 
     println!("Adding config files from examples.");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "nightly"
 profile = "minimal"
-components = ["clippy", "rustfmt"]
+components = ["clippy", "rustfmt", "rust-src"]


### PR DESCRIPTION
I finished my version of the release action. Life got busy, I was delayed. It looks like you created your own in the meantime. I merged them, as well as doing some cleanup, refactoring, and linting.

Minor changes overall. But I figured I might as well make a pull request anyway.

Instead of using an external action like `softprops/action-gh-release@v1` I used the built-in `gh` command. Reducing the number of external dependencies in the build process. (I believe the `gh` cli as well as `github-script` deprecate a lot of common third-party actions.)

I also added a cleaning step to the `cargo xtask dist` command to clean the `target/dist` directory before creating the new zip files in it. Probably not relevant since the CI should run in a clean environment, but might as well.

In the line of reducing dependencies, I removed the `clap` crate, and switched from `reqwest` to `ureq` using the native Windows TLS support for HTTPS. I also modified the `crates/common` crate to have feature gates, to let cybercmd compile without having to directly depend on everything xtask needs, meaning it won't rebuild those crates in the release profile.